### PR TITLE
Feat/orm order

### DIFF
--- a/src/Entity/Address.php
+++ b/src/Entity/Address.php
@@ -4,19 +4,40 @@ declare(strict_types=1);
 
 namespace App\Entity;
 
+use Doctrine\ORM\Mapping as ORM;
+use DateTime;
+
+#[ORM\Entity]
 class Address 
 {
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue]
+    private int $id;
+
+    #[ORM\Column]
     private string $street;
     
+    #[ORM\Column]
     private string $number;
 
+    #[ORM\Column]
     private string $zipcode;
 
+    #[ORM\Column]
     private string $district;
 
+    #[ORM\Column]
     private string $city;
 
+    #[ORM\Column]
     private string $state;
+
+    #[ORM\Column]
+    private DateTime $createdAt;
+    
+    #[ORM\Column]
+    private DateTime $updateAt;
 
     public function full(): string
     {

--- a/src/Entity/Customer.php
+++ b/src/Entity/Customer.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace App\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use DateTime;
 
 #[ORM\Entity]
 class Customer
 {
-
     #[ORM\Id]
     #[ORM\Column(type: 'integer')]
     #[ORM\GeneratedValue]
@@ -17,8 +17,9 @@ class Customer
 
     #[ORM\Column]
     private string $name;
-    
-    #[ORM\Column]
+
+    #[ORM\ManyToOne(targetEntity: Address::class)]
+    #[ORM\JoinColumn(name: 'customer_id', referencedColumnName: 'id')]
     private Address $address;
 
     #[ORM\Column]
@@ -32,6 +33,12 @@ class Customer
 
     #[ORM\Column(type: 'boolean')]
     private bool $status;
+
+    #[ORM\Column]
+    private DateTime $createdAt;
+    
+    #[ORM\Column]
+    private DateTime $updateAt;
 
     public function __construct(string $name, string $phone)
     {

--- a/src/Entity/Order.php
+++ b/src/Entity/Order.php
@@ -4,15 +4,35 @@ declare(strict_types=1);
 
 namespace App\Entity;
 
+use Doctrine\ORM\Mapping as ORM;
 use DateTime;
 
+#[ORM\Entity]
 class Order 
 {
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue]
+    private int $id;
+
+    
+    #[ORM\Column]
     private string $type;
+    
+    #[ORM\Column]
     private array $items;
+    
+    #[ORM\ManyToOne(targetEntity: Customer::class)]
+    #[ORM\JoinColumn(name: 'customer_id', referencedColumnName: 'id')]
     private Customer $customer;
+    
+    #[ORM\Column]
     private string $status;
+    
+    #[ORM\Column]
     private DateTime $createdAt;
+    
+    #[ORM\Column]
     private DateTime $updateAt;
 
     public function getType(): string

--- a/src/Entity/Order.php
+++ b/src/Entity/Order.php
@@ -8,6 +8,7 @@ use Doctrine\ORM\Mapping as ORM;
 use DateTime;
 
 #[ORM\Entity]
+#[ORM\Table(name: 'orders')]
 class Order 
 {
     #[ORM\Id]

--- a/src/Entity/Product.php
+++ b/src/Entity/Product.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-
 namespace App\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use DateTime;
 
 #[ORM\Entity]
 class Product
@@ -18,7 +18,8 @@ class Product
     #[ORM\Column]
     private string $name;
     
-    #[ORM\Column]
+    #[ORM\ManyToOne(targetEntity: Category::class)]
+    #[ORM\JoinColumn(name: 'category_id', referencedColumnName: 'id')]
     private Category $category;
     
     #[ORM\Column]
@@ -32,6 +33,12 @@ class Product
     
     #[ORM\Column (type: 'boolean')]
     private bool $available;
+
+    #[ORM\Column]
+    private DateTime $createdAt;
+    
+    #[ORM\Column]
+    private DateTime $updateAt;
 
     public function getName(): string
     {


### PR DESCRIPTION
Foi incluído o mapping do ORM da Entity Order. Para isso foi necessário fazer alterações com outras entidades que tinham relacionamento com essa primeira. Aproveitei o ensejo para padronizar a criação dos campos de createdAt e updatedAt nas Entity envolvidas.

![image](https://github.com/user-attachments/assets/79fcbace-09c5-4e9b-9c51-6d8e7e2e1870)
![image](https://github.com/user-attachments/assets/cce1d72e-c008-42e1-9031-08242030a96e)

fix #35 